### PR TITLE
Fix colorbox not updating on scheme apply + fix input bug

### DIFF
--- a/addon/components/configuration/colorpicker-settings.js
+++ b/addon/components/configuration/colorpicker-settings.js
@@ -18,15 +18,17 @@ export default Component.extend({
     applyColorScheme(value) {
       if (value === "default") {
         this.get('configuration').resetColors();
+        this.updateColorPickerElements();
       }
       else if (value === "impaired") {
         this.applyVisuallyImpairedColors();
+        this.updateColorPickerElements();
       }
       else {
         // Passed color scheme was invalid
         return;
       }
-    },
+    }
   },
 
   // @Override
@@ -37,21 +39,19 @@ export default Component.extend({
 
   // Initializes the colorpicker elements and related handlers/listeners
   initColorpicker() {
-    const self = this;
-    this.initColorPickerElements(self);
-    this.initHandlers(self);
+    this.initColorPickerElements();
   },
 
   // Configures the colorpicker elements and defines format, color, and fallback color
-  initColorPickerElements(self) {
+  initColorPickerElements() {
     let landscapeColors = this.get('configuration.landscapeColors');
     // Initialize landscape colorpickers
     for (let property in landscapeColors) {
       $(`#cp-landscape-${property}`).colorpicker(
         {
           format: "rgb",
-          fallbackColor: self.get('configuration.landscapeColorsDefault.' + property),
-          color: self.get('configuration.landscapeColors.' + property)
+          fallbackColor: this.get('configuration.landscapeColorsDefault.' + property),
+          color: this.get('configuration.landscapeColors.' + property)
         }
       );
     }
@@ -62,29 +62,24 @@ export default Component.extend({
       $(`#cp-application-${property}`).colorpicker(
         {
           format: "rgb",
-          fallbackColor: self.get('configuration.applicationColorsDefault.' + property),
-          color: self.get('configuration.applicationColors.' + property)
+          fallbackColor: this.get('configuration.applicationColorsDefault.' + property),
+          color: this.get('configuration.applicationColors.' + property)
         }
       );
     }
   },
 
-  // Setups the handlers / listeners for the colorpickers
-  initHandlers(self) {
-    // Landscape color handlers
+  updateColorPickerElements() {
     let landscapeColors = this.get('configuration.landscapeColors');
+    // update landscape colorpickers' values
     for (let property in landscapeColors) {
-      $(`#cp-landscape-${property}`).colorpicker().on('change', function (event) {
-        self.set('configuration.landscapeColors.' + property, event.value);
-      });
+      $(`#cp-landscape-${property}`).colorpicker('setValue', this.get('configuration.landscapeColors.' + property));
     }
 
-    // Application color Handlers
     let applicationColors = this.get('configuration.applicationColors');
+    // Initialize application colorpickers' values
     for (let property in applicationColors) {
-      $(`#cp-application-${property}`).colorpicker().on('change', function (event) {
-        self.set('configuration.applicationColors.' + property, event.value);
-      });
+      $(`#cp-application-${property}`).colorpicker('setValue', this.get('configuration.applicationColors.' + property));
     }
   },
 
@@ -118,23 +113,6 @@ export default Component.extend({
       communicationArrow: "rgb(0, 0, 0)",
       background: "rgb(255, 255, 255)"
     });
-  },
-
-  // @Override
-  willDestroyElement() {
-    this._super(...arguments);
-
-    // Reset landscape color handlers
-    let landscapeColors = this.get('configuration.landscapeColors');
-    for (let property in landscapeColors) {
-      $(`#cp-landscape-${property}`).colorpicker().off('change');
-    }
-
-    // Reset application color handlers
-    let applicationColors = this.get('configuration.applicationColors');
-    for (let property in applicationColors) {
-      $(`#cp-application-${property}`).colorpicker().off('change');
-    }
-  },
+  }
 
 });

--- a/addon/templates/components/configuration/colorpicker-settings.hbs
+++ b/addon/templates/components/configuration/colorpicker-settings.hbs
@@ -21,7 +21,7 @@
         <div class="col-md-6 col-lg-4 col-xl-3 mt-3">
             <div>{{format-property key}}</div>
             <div id="{{concat "cp-landscape-" key}}" class="input-group">
-                {{input type="text" class="form-control input-lg" value=color }}
+                {{input type="text" class="form-control input-lg" value=(mut (get this.configuration.landscapeColors key))}}
                 <span class="input-group-append">
                     <span class="input-group-text colorpicker-input-addon"><i></i></span>
                 </span>
@@ -37,7 +37,7 @@
         <div class="col-md-6 col-lg-4 col-xl-3 mt-3">
             <div>{{format-property key}}</div>
             <div id="{{concat "cp-application-" key}}" class="input-group">
-                {{input type="text" class="form-control input-lg" value=color }}
+                {{input type="text" class="form-control input-lg" value=(mut (get this.configuration.applicationColors key))}}
                 <span class="input-group-append">
                     <span class="input-group-text colorpicker-input-addon"><i></i></span>
                 </span>


### PR DESCRIPTION
The colorpickers' values are now explicitly set after the scheme is
applied, therefore matching the values of the scheme. The input field
now has a mutable value, thus rendering the event listeners on the
colorpicker redundant. So changing the input field's value will
automatically update the corresponding color property in the
configuration service. Furthermore, this fixes the input field being buggy
in the sense that the function called in the event of a color change was
setting the color property to undefined in some cases.